### PR TITLE
Typehints needed for PHP 8.1

### DIFF
--- a/src/VCR/Storage/AbstractStorage.php
+++ b/src/VCR/Storage/AbstractStorage.php
@@ -68,7 +68,7 @@ abstract class AbstractStorage implements Storage
      *
      * @return array<string,mixed>|null parsed current record
      */
-    public function current()
+    public function current(): ?array
     {
         return $this->current;
     }

--- a/src/VCR/Storage/Yaml.php
+++ b/src/VCR/Storage/Yaml.php
@@ -88,7 +88,7 @@ class Yaml extends AbstractStorage
         $this->position = 0;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         if (null === $this->current) {
             $this->next();


### PR DESCRIPTION
### Context

We are using this in the billing repo, and due to upgrading to Laravel 9 + PHP 8.1, we are getting deprecation notices.

### What has been done

Added type hints to fix the deprecation notices

