### PR TITLE
PACM-2423 Disable SOAP support

### DIFF
--- a/src/VCR/Configuration.php
+++ b/src/VCR/Configuration.php
@@ -42,7 +42,7 @@ class Configuration
     private $availableLibraryHooks = [
         'stream_wrapper' => 'VCR\LibraryHooks\StreamWrapperHook',
         'curl' => 'VCR\LibraryHooks\CurlHook',
-        'soap' => 'VCR\LibraryHooks\SoapHook',
+        //'soap' => 'VCR\LibraryHooks\SoapHook',
     ];
 
     /**


### PR DESCRIPTION
Removes SOAP support so that SOAP isn't a required package in services that use VCR

